### PR TITLE
[WIP] Delete and Rename features

### DIFF
--- a/bidshandler/bidstree.py
+++ b/bidshandler/bidstree.py
@@ -198,6 +198,7 @@ class BIDSTree(QueryMixin):
                         "contained.")
 
     def __iter__(self):
+        """Iterable of the contained Project objects."""
         return iter(self.projects)
 
     def __getitem__(self, item):

--- a/bidshandler/project.py
+++ b/bidshandler/project.py
@@ -209,7 +209,7 @@ class Project(QueryMixin):
 
     @property
     def description(self):
-        """Real path to the associated description if there is one."""
+        """Path to the associated description if there is one."""
         _path = None
         if self._description is not None:
             _path = _realize_paths(self, self._description)
@@ -223,6 +223,7 @@ class Project(QueryMixin):
     @property
     def inheritable_files(self):
         """List of files that are able to be inherited by child objects."""
+        # TODO: make private?
         files = []
         for fname in os.listdir(self.path):
             abs_path = _realize_paths(self, fname)
@@ -232,7 +233,7 @@ class Project(QueryMixin):
 
     @property
     def participants_tsv(self):
-        """Real path to the associated participants.tsv if there is one."""
+        """Path to the associated participants.tsv if there is one."""
         _path = None
         if self._participants_tsv is not None:
             _path = _realize_paths(self, self._participants_tsv)
@@ -240,12 +241,12 @@ class Project(QueryMixin):
 
     @property
     def path(self):
-        """Determine path location based on parent paths."""
+        """Path to Project folder."""
         return op.join(self.bids_tree.path, self.ID)
 
     @property
     def readme(self):
-        """Real path to the associated README.txt if there is one."""
+        """Path to the associated README.txt if there is one."""
         _path = None
         if self._readme is not None:
             _path = _realize_paths(self, self._readme)
@@ -253,7 +254,13 @@ class Project(QueryMixin):
 
     @property
     def sessions(self):
-        """List of all Sessions contained in the Project."""
+        """List of all contained :class:`bidshandler.Session`'s.
+
+        Returns
+        -------
+        list of :class:`bidshandler.Session`
+            All Sessions within this Project.
+        """
         session_list = []
         for subject in self.subjects:
             session_list.extend(subject.sessions)
@@ -261,7 +268,13 @@ class Project(QueryMixin):
 
     @property
     def scans(self):
-        """List of all Scans contained in the Project."""
+        """List of all contained :class:`bidshandler.Scan`'s.
+
+        Returns
+        -------
+        list of :class:`bidshandler.Scan`
+            All Scans within this Project.
+        """
         scan_list = []
         for subject in self.subjects:
             scan_list.extend(subject.scans)
@@ -269,7 +282,13 @@ class Project(QueryMixin):
 
     @property
     def subjects(self):
-        """List of all Subjects contained in the Project."""
+        """List of all contained :class:`bidshandler.Subject`'s.
+
+        Returns
+        -------
+        list of :class:`bidshandler.Subject`
+            All Subjects within this Project.
+        """
         return list(self._subjects.values())
 
 #region class methods
@@ -300,6 +319,7 @@ class Project(QueryMixin):
                         "contained.")
 
     def __iter__(self):
+        """Iterable of the contained Subject objects."""
         return iter(self._subjects.values())
 
     def __getitem__(self, item):

--- a/bidshandler/project.py
+++ b/bidshandler/project.py
@@ -309,7 +309,7 @@ class Project(QueryMixin):
         return '<Project, ID: {0}, {1} subject{2}, @ {3}>'.format(
             self.ID,
             len(self.subjects),
-            ('s' if len(self.subjects) > 1 else ''),
+            ('s' if len(self.subjects) != 1 else ''),
             self.path)
 
     def __str__(self):

--- a/bidshandler/project.py
+++ b/bidshandler/project.py
@@ -210,9 +210,10 @@ class Project(QueryMixin):
     @property
     def description(self):
         """Real path to the associated description if there is one."""
+        _path = None
         if self._description is not None:
-            return _realize_paths(self, self._description)
-        return None
+            _path = _realize_paths(self, self._description)
+        return _path
 
     @property
     def ID(self):
@@ -232,9 +233,10 @@ class Project(QueryMixin):
     @property
     def participants_tsv(self):
         """Real path to the associated participants.tsv if there is one."""
+        _path = None
         if self._participants_tsv is not None:
-            return _realize_paths(self, self._participants_tsv)
-        return None
+            _path = _realize_paths(self, self._participants_tsv)
+        return _path
 
     @property
     def path(self):
@@ -244,9 +246,10 @@ class Project(QueryMixin):
     @property
     def readme(self):
         """Real path to the associated README.txt if there is one."""
+        _path = None
         if self._readme is not None:
-            return _realize_paths(self, self._readme)
-        return None
+            _path = _realize_paths(self, self._readme)
+        return _path
 
     @property
     def sessions(self):

--- a/bidshandler/querymixin.py
+++ b/bidshandler/querymixin.py
@@ -233,9 +233,7 @@ class QueryMixin():
 
     @property
     def projects(self):
-        """
-        List of contained projects or self if the object itself is a Project
-        """
+        # List of contained projects or self if the object itself is a Project.
         from .project import Project
         if isinstance(self, Project):
             return [self]
@@ -246,9 +244,7 @@ class QueryMixin():
 
     @property
     def subjects(self):
-        """
-        List of contained subjects or self if the object itself is a Subject
-        """
+        # List of contained subjects or self if the object itself is a Subject.
         from .subject import Subject
         if isinstance(self, Subject):
             return [self]
@@ -259,9 +255,7 @@ class QueryMixin():
 
     @property
     def sessions(self):
-        """
-        List of contained sessions or self if the object itself is a Session
-        """
+        # List of contained sessions or self if the object itself is a Session.
         from .session import Session
         if isinstance(self, Session):
             return [self]
@@ -272,13 +266,9 @@ class QueryMixin():
 
     @property
     def scans(self):
-        """
-        The Scan object itself.
-
-        Note
-        ----
-        This is overwritten by every inheriting class except the Scan class.
-        """
+        # The Scan object itself.
+        # Note:
+        # This is overwritten by every inheriting class except the Scan class.
         return [self]
 
 #region class methods

--- a/bidshandler/scan.py
+++ b/bidshandler/scan.py
@@ -6,6 +6,8 @@ import xml.etree.ElementTree as ET
 from warnings import warn
 import shutil
 
+import pandas as pd
+
 from .querymixin import QueryMixin
 from .utils import (_get_bids_params, _realize_paths, _multi_replace,
                     _bids_params_are_subsets, _splitall, _fix_folderless,
@@ -86,6 +88,14 @@ class Scan(QueryMixin):
                     os.remove(fname)
         # remove the raw file
         os.remove(self.raw_file)
+
+        # remove the scan information from the scans.tsv
+        if self.session.scans_tsv is not None:
+            df = pd.read_csv(self.session.scans_tsv, sep='\t')
+            row_idx = df[df['filename'] == self.raw_file_relative].index.item()
+            df = df.drop(row_idx)
+            df.to_csv(self.session.scans_tsv, sep='\t', index=False,
+                      na_rep='n/a', encoding='utf-8')
         # is the directory is empty remove it
         if len(list(_file_list(self.path))) == 0:
             shutil.rmtree(self.path)

--- a/bidshandler/scan.py
+++ b/bidshandler/scan.py
@@ -260,7 +260,7 @@ class Scan(QueryMixin):
 
     @property
     def channels_tsv(self):
-        """Absolute path to the associated channels.tsv file."""
+        """Path to the associated channels.tsv file if there is one."""
         _path = None
         channels_path = self.associated_files.get('channels')
         if channels_path is not None:
@@ -269,7 +269,7 @@ class Scan(QueryMixin):
 
     @property
     def coordsystem_json(self):
-        """Absolute path to the associated coordsystem.json file."""
+        """Path to the associated coordsystem.json file if there is one."""
         _path = None
         coordsystem_path = self.associated_files.get('coordsystem')
         if coordsystem_path is not None:
@@ -319,7 +319,7 @@ class Scan(QueryMixin):
 
     @property
     def path(self):
-        """Determine path location based on parent paths."""
+        """Path of folder containing Scan."""
         return op.join(self.session.path, self._path)
 
     @property
@@ -329,22 +329,26 @@ class Scan(QueryMixin):
 
     @property
     def raw_file(self):
-        """Absolute path of associated raw file."""
+        """Path of associated raw file."""
         return _realize_paths(self, self._raw_file)
 
     @property
     def raw_file_relative(self):
-        """Relative path (to parent session) of associated raw file."""
+        """Path of associated raw file relative to parent Session."""
         return op.join(self._path, self._raw_file)
 
     @property
     def scan_type(self):
-        """Scan type."""
+        """Type of Scan.
+
+        This will be the name of the folder the Scan resides in.
+        Eg. `meg` for MEG data, `func` for fMRI data.
+        """
         return self._path
 
     @property
     def sidecar(self):
-        """Absolute path of associated sidecar file."""
+        """Path of associated sidecar file if there is one."""
         _path = None
         if self._sidecar is not None:
             _path = _realize_paths(self, self._sidecar)

--- a/bidshandler/scan.py
+++ b/bidshandler/scan.py
@@ -220,18 +220,20 @@ class Scan(QueryMixin):
     @property
     def channels_tsv(self):
         """Absolute path to the associated channels.tsv file."""
+        _path = None
         channels_path = self.associated_files.get('channels')
         if channels_path is not None:
-            return _realize_paths(self, channels_path)
-        return None
+            _path = _realize_paths(self, channels_path)
+        return _path
 
     @property
     def coordsystem_json(self):
         """Absolute path to the associated coordsystem.json file."""
+        _path = None
         coordsystem_path = self.associated_files.get('coordsystem')
         if coordsystem_path is not None:
-            return _realize_paths(self, coordsystem_path)
-        return None
+            _path = _realize_paths(self, coordsystem_path)
+        return _path
 
     @property
     def emptyroom(self):
@@ -246,13 +248,14 @@ class Scan(QueryMixin):
         ----
         Only for MEG scans.
         """
+        _path = None
         if self.scan_type == 'meg':
             emptyroom = self.info.get('AssociatedEmptyRoom')
             if emptyroom is not None:
                 fname = op.basename(emptyroom)
                 bids_params = _get_bids_params(fname)
                 try:
-                    return self.project.subject(
+                    _path = self.project.subject(
                         bids_params['sub']).session(
                             bids_params['ses']).scan(
                                 task=bids_params.get('task'),
@@ -261,15 +264,17 @@ class Scan(QueryMixin):
                 except (KeyError, NoScanError):
                     msg = 'Associated empty room file for {0} cannot be found'
                     warn(msg.format(str(self)))
-                    return None
+                    _path = None
+        return _path
 
     @property
     def events_tsv(self):
         """Absolute path to the associated events.tsv file."""
+        _path = None
         events_path = self.associated_files.get('events')
         if events_path is not None:
-            return _realize_paths(self, events_path)
-        return None
+            _path = _realize_paths(self, events_path)
+        return _path
 
     @property
     def path(self):
@@ -299,9 +304,10 @@ class Scan(QueryMixin):
     @property
     def sidecar(self):
         """Absolute path of associated sidecar file."""
+        _path = None
         if self._sidecar is not None:
-            return _realize_paths(self, self._sidecar)
-        return None
+            _path = _realize_paths(self, self._sidecar)
+        return _path
 
     @property
     def subject(self):

--- a/bidshandler/session.py
+++ b/bidshandler/session.py
@@ -375,6 +375,8 @@ class Session(QueryMixin):
         if old_id != self._id:
             self.subject._sessions[self._id] = self
             del self.subject._sessions[old_id]
+        if self._id != 'none':
+            self.has_no_folder = False
 
 #region properties
 

--- a/bidshandler/session.py
+++ b/bidshandler/session.py
@@ -147,7 +147,8 @@ class Session(QueryMixin):
             # Delete the scan. This will remove it from this sessions' scan
             # list.
             scan.delete()
-        os.remove(self.scans_tsv)
+        if self.scans_tsv is not None:
+            os.remove(self.scans_tsv)
         if len(list(_file_list(self.path))) == 0:
             shutil.rmtree(self.path)
 

--- a/bidshandler/session.py
+++ b/bidshandler/session.py
@@ -431,6 +431,7 @@ class Session(QueryMixin):
     @property
     def inheritable_files(self):
         """List of files that are able to be inherited by child objects."""
+        # TODO: make private?
         files = self.subject.inheritable_files
         for fname in os.listdir(self.path):
             abs_path = _realize_paths(self, fname)
@@ -440,7 +441,7 @@ class Session(QueryMixin):
 
     @property
     def path(self):
-        """Determine path location based on parent paths."""
+        """Path to Session folder."""
         if self.has_no_folder:
             return self.subject.path
         return _realize_paths(self.subject, self.ID)
@@ -452,12 +453,18 @@ class Session(QueryMixin):
 
     @property
     def scans(self):
-        """List of contained Scans."""
+        """List of all contained :class:`bidshandler.Scan`'s.
+
+        Returns
+        -------
+        list of :class:`bidshandler.Scan`
+            All Scans within this Session.
+        """
         return self._scans
 
     @property
     def scans_tsv(self):
-        """Absolute path of associated scans.tsv file."""
+        """Path of associated scans.tsv file if there is one."""
         _path = None
         if self._scans_tsv is not None:
             _path = _realize_paths(self, self._scans_tsv)
@@ -486,6 +493,7 @@ class Session(QueryMixin):
         raise TypeError("Can only determine if a Scan is contained.")
 
     def __iter__(self):
+        """Iterable of the contained Scan objects."""
         return iter(self._scans)
 
     def __repr__(self):

--- a/bidshandler/subject.py
+++ b/bidshandler/subject.py
@@ -75,22 +75,25 @@ class Subject(QueryMixin):
             else:
                 raise ValueError("Added subject must have same ID.")
         elif isinstance(other, Session):
-            # check to see if we have only one scan without a session folder:
+            # Check to see if we have only one scan without a session folder:
             if not (self._id == other.subject._id and
                     self.project._id == other.project._id):
                 raise AssociationError("session", "project and subject")
-
-            if len(self.sessions) == 1:
-                session = self.sessions[0]
-                if session.has_no_folder:
-                    # in this case the session has to be given a folder
-                    # and moved, then the new folder can also be added.
-                    moved_session = Session._clone_into_subject(
-                        self, session, create_in_folder=True)
-                    print(moved_session)
             if other in self:
+                # if the other session being added has the same ID, merge it
+                # with the current session with that ID.
                 self.session(other._id).add(other, copier)
             else:
+                if len(self.sessions) == 1:
+                    # If we have only one existing session, we want to
+                    # check whether the existing session has no actual
+                    # session folder.
+                    if self.sessions[0].has_no_folder:
+                        print("Current Subject has only one session with no "
+                              "specified session id. Please set this "
+                              "sessions' id by renaming it using "
+                              "`self.sessions[0].rename(1)` (or other number)")
+                        return
                 new_session = Session._clone_into_subject(self, other)
                 new_session.add(other, copier)
                 self._sessions[other._id] = new_session
@@ -165,7 +168,7 @@ class Subject(QueryMixin):
         # assume that the current folder is in fact the session folder (ie.
         # only one session).
         if len(self._sessions) == 0:
-            self._sessions['01'] = Session('01', self, no_folder=True)
+            self._sessions['none'] = Session('none', self, no_folder=True)
 
     def _check(self):
         """Check that there is at least one included session."""

--- a/bidshandler/subject.py
+++ b/bidshandler/subject.py
@@ -273,7 +273,7 @@ class Subject(QueryMixin):
             df = pd.read_csv(self.project.participants_tsv, sep='\t')
             for idx, row in enumerate(df['participant_id']):
                 if row == old_subj_id:
-                    df['participant_id'][idx] = new_subj_id
+                    df.at[idx, 'participant_id'] = new_subj_id
                     break
             df.to_csv(self.project.participants_tsv, sep='\t', index=False,
                       na_rep='n/a', encoding='utf-8')

--- a/bidshandler/subject.py
+++ b/bidshandler/subject.py
@@ -374,7 +374,7 @@ class Subject(QueryMixin):
         return '<Subject, ID: {0}, {1} session{2}, @ {3}>'.format(
             self.ID,
             len(self.sessions),
-            ('s' if len(self.sessions) > 1 else ''),
+            ('s' if len(self.sessions) != 1 else ''),
             self.path)
 
     def __str__(self):

--- a/bidshandler/subject.py
+++ b/bidshandler/subject.py
@@ -90,10 +90,11 @@ class Subject(QueryMixin):
                     # check whether the existing session has no actual
                     # session folder.
                     if self.sessions[0].has_no_folder:
-                        print("Current Subject has only one session with no "
-                              "specified session id. Please set this "
-                              "sessions' id by renaming it using "
-                              "`self.sessions[0].rename(1)` (or other number)")
+                        warn("Current Subject has only one session with no "
+                             "specified session id. Please set this "
+                             "sessions' id by renaming it using "
+                             "`self.sessions[0].rename(1)` (or other number). "
+                             "The session to be added will not be added.")
                         return
                 new_session = Session._clone_into_subject(self, other)
                 new_session.add(other, copier)

--- a/bidshandler/subject.py
+++ b/bidshandler/subject.py
@@ -130,9 +130,30 @@ class Subject(QueryMixin):
         return file_list
 
     def delete(self):
-        pass
+        """Delete the  subject from the parent Project."""
+        for session in self.sessions[:]:
+            session.delete()
+        # remove the subject information from the participants.tsv
+        if self.project.participants_tsv is not None:
+            df = pd.read_csv(self.project.participants_tsv, sep='\t')
+            row_idx = df[df['participant_id'] == self.ID].index.item()
+            df = df.drop(row_idx)
+            df.to_csv(self.project.participants_tsv, sep='\t', index=False,
+                      na_rep='n/a', encoding='utf-8')
+
+        if len(list(_file_list(self.path))) == 0:
+            shutil.rmtree(self.path)
+
+        del self.project._subjects[self._id]
 
     def rename(self, id_):
+        """Change the subjects' id.
+
+        Parameters
+        ----------
+        id_ : str
+            New id for the subject object.
+        """
         self._rename(id_)
 
     def session(self, id_):

--- a/bidshandler/subject.py
+++ b/bidshandler/subject.py
@@ -331,6 +331,7 @@ class Subject(QueryMixin):
     @property
     def inheritable_files(self):
         """List of files that are able to be inherited by child objects."""
+        # TODO: make private?
         files = self.project.inheritable_files
         for fname in os.listdir(self.path):
             abs_path = _realize_paths(self, fname)
@@ -340,12 +341,18 @@ class Subject(QueryMixin):
 
     @property
     def path(self):
-        """Determine path location based on parent paths."""
+        """Path of Subject folder."""
         return op.join(self.project.path, self.ID)
 
     @property
     def scans(self):
-        """List of contained Scans."""
+        """List of all contained :class:`bidshandler.Scan`'s.
+
+        Returns
+        -------
+        list of :class:`bidshandler.Scan`
+            All Scans within this Subject.
+        """
         scan_list = []
         for session in self.sessions:
             scan_list.extend(session.scans)
@@ -353,7 +360,13 @@ class Subject(QueryMixin):
 
     @property
     def sessions(self):
-        """List of contained Sessions."""
+        """List of all contained :class:`bidshandler.Session`'s.
+
+        Returns
+        -------
+        list of :class:`bidshandler.Session`
+            All Sessions within this Subject.
+        """
         return list(self._sessions.values())
 
 #region class methods
@@ -384,6 +397,7 @@ class Subject(QueryMixin):
                         "contained.")
 
     def __iter__(self):
+        """Iterable of the contained Session objects."""
         return iter(self._sessions.values())
 
     def __getitem__(self, item):

--- a/bidshandler/subject.py
+++ b/bidshandler/subject.py
@@ -3,6 +3,7 @@ import os.path as op
 from collections import OrderedDict
 import xml.etree.ElementTree as ET
 import shutil
+from warnings import warn
 
 import pandas as pd
 
@@ -282,11 +283,11 @@ class Subject(QueryMixin):
                       na_rep='n/a', encoding='utf-8')
 
         # remove the old path
-        # TODO: check to see if the folders are empty.
         if len(os.listdir(old_path)) == 0:
             shutil.rmtree(old_path)
         else:
-            print(os.listdir(old_path))
+            warn_msg = "The following files haven't been moved correctly:\n{0}"
+            warn(warn_msg.format("\n".join(os.listdir(old_path))))
 
         self._id = subj_id
 

--- a/bidshandler/subject.py
+++ b/bidshandler/subject.py
@@ -11,7 +11,7 @@ from .bidserrors import MappingError, NoSessionError, AssociationError
 from .session import Session
 from .scan import Scan
 from .querymixin import QueryMixin
-from .utils import _copyfiles, _realize_paths
+from .utils import _copyfiles, _realize_paths, _file_list
 
 
 class Subject(QueryMixin):
@@ -283,11 +283,13 @@ class Subject(QueryMixin):
                       na_rep='n/a', encoding='utf-8')
 
         # remove the old path
-        if len(os.listdir(old_path)) == 0:
+        if len(list(_file_list(old_path))) == 0:
             shutil.rmtree(old_path)
         else:
             warn_msg = "The following files haven't been moved correctly:\n{0}"
-            warn(warn_msg.format("\n".join(os.listdir(old_path))))
+            warn(warn_msg.format(
+                "\n".join(
+                    [_realize_paths(self, p) for p in os.listdir(old_path)])))
 
         self._id = subj_id
 

--- a/bidshandler/tests/test_add.py
+++ b/bidshandler/tests/test_add.py
@@ -46,7 +46,7 @@ def test_merge_bidstrees():
         dst_bt = BIDSTree(op.join(tmp, 'BIDSTEST2'))
         dst_bt.add(src_bt)
         assert len(dst_bt.projects) == 2
-        raw = dst_bt.project('test1').subject('2').session('1').scan(
+        raw = dst_bt.project('test1').subject('2').session('none').scan(
             task='restingstate', run='1').raw_file
         assert op.exists(raw)
 

--- a/bidshandler/tests/test_add.py
+++ b/bidshandler/tests/test_add.py
@@ -19,22 +19,22 @@ def test_add_new_project_recursively():
     with tempfile.TemporaryDirectory() as tmp:
         # copy the dst to a temp folder
         shutil.copytree(TESTPATH2, op.join(tmp, 'BIDSTEST2'))
-        src_bf = BIDSTree(TESTPATH1)
-        dst_bf = BIDSTree(op.join(tmp, 'BIDSTEST2'))
-        scan = src_bf.project('test2').subject('3').session('1').scan(
+        src_bt = BIDSTree(TESTPATH1)
+        dst_bt = BIDSTree(op.join(tmp, 'BIDSTEST2'))
+        scan = src_bt.project('test2').subject('3').session('1').scan(
             task='resting', run='1')
         assert scan.emptyroom is not None
-        dst_bf.add(scan)
+        dst_bt.add(scan)
         # make sure the project was added
-        assert len(dst_bf.projects) == 2
-        assert op.exists(dst_bf.project('test2').readme)
-        assert op.exists(dst_bf.project('test2').description)
+        assert len(dst_bt.projects) == 2
+        assert op.exists(dst_bt.project('test2').readme)
+        assert op.exists(dst_bt.project('test2').description)
         # make sure the subject was added and the empty room data was too
-        assert len(dst_bf.project('test2').subjects) == 2
+        assert len(dst_bt.project('test2').subjects) == 2
         # make sure the scan was added
-        scans_tsv = dst_bf.project('test2').subject('3').session('1').scans_tsv
+        scans_tsv = dst_bt.project('test2').subject('3').session('1').scans_tsv
         assert op.exists(scans_tsv)
-        dst_bf.project('test2').subject('emptyroom')
+        dst_bt.project('test2').subject('emptyroom')
 
 
 def test_merge_bidstrees():
@@ -42,11 +42,11 @@ def test_merge_bidstrees():
     with tempfile.TemporaryDirectory() as tmp:
         # copy the dst to a temp folder
         shutil.copytree(TESTPATH2, op.join(tmp, 'BIDSTEST2'))
-        src_bf = BIDSTree(TESTPATH1)
-        dst_bf = BIDSTree(op.join(tmp, 'BIDSTEST2'))
-        dst_bf.add(src_bf)
-        assert len(dst_bf.projects) == 2
-        raw = dst_bf.project('test1').subject('2').session('1').scan(
+        src_bt = BIDSTree(TESTPATH1)
+        dst_bt = BIDSTree(op.join(tmp, 'BIDSTEST2'))
+        dst_bt.add(src_bt)
+        assert len(dst_bt.projects) == 2
+        raw = dst_bt.project('test1').subject('2').session('1').scan(
             task='restingstate', run='1').raw_file
         assert op.exists(raw)
 
@@ -55,8 +55,8 @@ def test_bidstree_to_bidstree():
     # Test writing one BIDSTree object to a new empty BIDSTree location.
     with tempfile.TemporaryDirectory() as tmp:
         dest_bf = BIDSTree(tmp, False)
-        src_bf = BIDSTree(TESTPATH2)
-        dest_bf.add(src_bf)
+        src_bt = BIDSTree(TESTPATH2)
+        dest_bf.add(src_bt)
         assert len(dest_bf.projects) == 1
         assert dest_bf.project('test1').subject('1').subject_data['age'] == 2.0
 
@@ -66,41 +66,41 @@ def test_copy_errors():
     with tempfile.TemporaryDirectory() as tmp:
         # copy the dst to a temp folder
         shutil.copytree(TESTPATH2, op.join(tmp, 'BIDSTEST2'))
-        src_bf = BIDSTree(TESTPATH1)
-        dst_bf = BIDSTree(op.join(tmp, 'BIDSTEST2'))
+        src_bt = BIDSTree(TESTPATH1)
+        dst_bt = BIDSTree(op.join(tmp, 'BIDSTEST2'))
         # try add one project to another with different ID's
         # try and add an object you shouldn't do:
-        proj = src_bf.project('test1')
+        proj = src_bt.project('test1')
         with pytest.raises(TypeError):
-            dst_bf.project('test1').subject('1').session('1').add(proj)
+            dst_bt.project('test1').subject('1').session('1').add(proj)
         with pytest.raises(TypeError):
-            dst_bf.project('test1').subject('1').add(proj)
+            dst_bt.project('test1').subject('1').add(proj)
         with pytest.raises(TypeError):
-            dst_bf.project('test1').add(src_bf)
+            dst_bt.project('test1').add(src_bt)
 
-        proj = src_bf.project('test2')
+        proj = src_bt.project('test2')
         sub = proj.subject('3')
         ses = sub.session('1')
         scan = ses.scan(task='resting', run='1')
         # try and add objects in the wrong project:
         with pytest.raises(ValueError):
-            dst_bf.project('test1').add(proj)
+            dst_bt.project('test1').add(proj)
         with pytest.raises(AssociationError):
-            dst_bf.project('test1').add(sub)
+            dst_bt.project('test1').add(sub)
         with pytest.raises(AssociationError):
-            dst_bf.project('test1').add(ses)
+            dst_bt.project('test1').add(ses)
         with pytest.raises(AssociationError):
-            dst_bf.project('test1').add(scan)
+            dst_bt.project('test1').add(scan)
         # try and add objects to the wrong subject:
         with pytest.raises(ValueError):
-            dst_bf.project('test1').subject('1').add(sub)
+            dst_bt.project('test1').subject('1').add(sub)
         with pytest.raises(AssociationError):
-            dst_bf.project('test1').subject('1').add(ses)
+            dst_bt.project('test1').subject('1').add(ses)
         with pytest.raises(AssociationError):
-            dst_bf.project('test1').subject('1').add(scan)
+            dst_bt.project('test1').subject('1').add(scan)
         # try and add objects to the wrong session:
         with pytest.raises(ValueError):
-            session = src_bf.project('test1').subject('1').session('2')
-            dst_bf.project('test1').subject('1').session('1').add(session)
+            session = src_bt.project('test1').subject('1').session('2')
+            dst_bt.project('test1').subject('1').session('1').add(session)
         with pytest.raises(AssociationError):
-            dst_bf.project('test1').subject('1').session('1').add(scan)
+            dst_bt.project('test1').subject('1').session('1').add(scan)

--- a/bidshandler/tests/test_load.py
+++ b/bidshandler/tests/test_load.py
@@ -4,6 +4,7 @@ import tempfile
 import os.path as op
 import shutil
 import pytest
+from datetime import date
 
 from bidshandler import (BIDSTree, NoSessionError, NoSubjectError,
                          NoProjectError, NoScanError)
@@ -39,6 +40,9 @@ def test_containment():
         # check some emptyroom values
         sess2 = src_bt.project('test2').subject('3').session('1')
         assert sess2.scan(task='resting', run='1').emptyroom is not None
+
+        # check the session date is correct
+        assert sess.date == date(year=2018, month=10, day=26)
 
         # check regex works for scans
         with pytest.raises(Exception, match='Multiple'):

--- a/bidshandler/tests/test_load.py
+++ b/bidshandler/tests/test_load.py
@@ -1,4 +1,4 @@
-# test various aspects of loading BIDS folders
+# Test various aspects of loading BIDS folders
 
 import tempfile
 import os.path as op
@@ -20,7 +20,7 @@ TESTPATH3 = op.join(testpath, 'bids-examples')
 
 def test_containment():
     with tempfile.TemporaryDirectory() as tmp:
-        # copy the dst to a temp folder
+        # Copy the dst to a temp folder.
         shutil.copytree(TESTPATH2, op.join(tmp, 'BIDSTEST2'))
         src_bt = BIDSTree(TESTPATH1)
         dst_bt = BIDSTree(op.join(tmp, 'BIDSTEST2'))
@@ -39,14 +39,14 @@ def test_containment():
         assert scan in dst_bt.project('test1')
         assert scan in dst_bt
         assert scan.scan_type == 'meg'
-        # check some emptyroom values
+        # Check some emptyroom values.
         sess2 = src_bt.project('test2').subject('3').session('1')
         assert sess2.scan(task='resting', run='1').emptyroom is not None
 
-        # check the session date is correct
+        # Check the session date is correct.
         assert sess.date == date(year=2018, month=10, day=26)
 
-        # check regex works for scans
+        # Check regex works for scans.
         with pytest.raises(Exception, match='Multiple'):
             sess.scan(run='1')
         assert len(sess.scan(run='1', return_all=True)) == 2
@@ -66,7 +66,7 @@ def test_containment():
             assert dst_bt in sess
 
         # Check the paths for the associated `channels`, `events` and
-        # `coordsystem` file are correct
+        # `coordsystem` file are correct.
         assert scan.coordsystem_json == op.normpath(op.join(testpath, 'BIDSTEST1/test1/sub-1/ses-1/meg/sub-1_ses-1_coordsystem.json'))  # noqa
         assert scan.events_tsv == op.normpath(op.join(testpath, 'BIDSTEST1/test1/sub-1/ses-1/meg/sub-1_ses-1_task-resting_run-1_events.tsv'))  # noqa
         assert scan.channels_tsv == op.normpath(op.join(testpath, 'BIDSTEST1/test1/sub-1/ses-1/meg/sub-1_ses-1_task-resting_run-1_channels.tsv'))  # noqa
@@ -85,7 +85,7 @@ def test_containment():
         assert len(dst_bt['test1'].contained_files()) == 19
 
         # Check that some inherited properties correctly aren't defined for
-        # objects they shouldn't be
+        # objects they shouldn't be.
         with pytest.raises(AttributeError):
             subj.projects
         with pytest.raises(AttributeError):
@@ -95,20 +95,33 @@ def test_containment():
 
 
 def test_deleting():
-    # make sure that data is removed correctly
+    # Make sure that data is removed correctly.
     with tempfile.TemporaryDirectory() as tmp:
-        # copy the dst to a temp folder
+        # Copy the dst to a temp folder.
         shutil.copytree(TESTPATH1, op.join(tmp, 'BIDSTEST1'))
         bt = BIDSTree(op.join(tmp, 'BIDSTEST1'))
 
-        # TODO: add test for deleting a scan
+        # Delete a specific scan.
+        bt.project('test1').subject(1).session(1).scan(
+            task='optimumMMN', run='1').delete()
+        scans_tsv = bt.project('test1').subject(1).session(1).scans_tsv
+        df = pd.read_csv(scans_tsv, sep='\t')
+        # Make sure the scan isn't listed in the scans.tsv
+        assert 'meg\\sub-1_ses-1_task-optimumMMN_run-1_meg\\sub-1_ses-1_task-optimumMMN_run-1_meg.con' not in df['filename']  # noqa
+        # Check that the other files that are used by both scans in the folder
+        # are still there.
+        other_scan = bt.project('test1').subject(1).session(1).scan(
+            task='resting', run='1')
+        assert op.exists(other_scan.coordsystem_json)
+        assert op.exists(op.join(other_scan.path,
+                                 other_scan.associated_files['headshape']))
 
-        # check deleting a session object works correctly
+        # Check deleting a session object works correctly.
         bt.project('test1').subject(1).session(1).delete()
         with pytest.raises(NoSessionError):
             bt.project('test1').subject(1).session(1)
 
-        # check deleting a subject object works correctly
+        # Check deleting a subject object works correctly.
         bt.project('test1').subject(1).delete()
         with pytest.raises(NoSubjectError):
             bt.project('test1').subject(1)
@@ -118,6 +131,6 @@ def test_deleting():
 
 
 def test_large_dataset():
-    # Test loading the bids-example dataset
+    # Test loading the bids-example dataset.
     tree = BIDSTree(TESTPATH3)
     assert len(tree.projects) == 29

--- a/bidshandler/tests/test_load.py
+++ b/bidshandler/tests/test_load.py
@@ -91,6 +91,11 @@ def test_containment():
         with pytest.raises(AttributeError):
             scan.sessions
 
+        # check deleting a session object works correctly
+        dst_bt.project('test1').subject(1).session(1).delete()
+        with pytest.raises(NoSessionError):
+            sess = dst_bt.project('test1').subject(1).session(1)
+
 
 def test_large_dataset():
     # Test loading the bids-example dataset

--- a/bidshandler/tests/test_load.py
+++ b/bidshandler/tests/test_load.py
@@ -76,7 +76,7 @@ def test_containment():
         with pytest.raises(NoScanError):
             scan = sess.scan(task='fake')
 
-        assert len(dst_bf['test1'].contained_files()) == 10
+        assert len(dst_bf['test1'].contained_files()) == 19
 
         # Check that some inherited properties correctly aren't defined for
         # objects they shouldn't be

--- a/bidshandler/tests/test_load.py
+++ b/bidshandler/tests/test_load.py
@@ -19,25 +19,25 @@ def test_containment():
     with tempfile.TemporaryDirectory() as tmp:
         # copy the dst to a temp folder
         shutil.copytree(TESTPATH2, op.join(tmp, 'BIDSTEST2'))
-        src_bf = BIDSTree(TESTPATH1)
-        dst_bf = BIDSTree(op.join(tmp, 'BIDSTEST2'))
+        src_bt = BIDSTree(TESTPATH1)
+        dst_bt = BIDSTree(op.join(tmp, 'BIDSTEST2'))
 
-        proj = src_bf.project('test1')
+        proj = src_bt.project('test1')
         subj = proj.subject('1')
         sess = subj.session('1')
         scan = sess.scan(task='resting', run='1')
-        assert subj in dst_bf.project('test1')
-        assert subj in dst_bf
-        assert sess in dst_bf.project('test1').subject('1')
-        assert sess in dst_bf.project('test1')
-        assert sess in dst_bf
-        assert scan in dst_bf.project('test1').subject(1).session(1)
-        assert scan in dst_bf.project('test1').subject(1)
-        assert scan in dst_bf.project('test1')
-        assert scan in dst_bf
+        assert subj in dst_bt.project('test1')
+        assert subj in dst_bt
+        assert sess in dst_bt.project('test1').subject('1')
+        assert sess in dst_bt.project('test1')
+        assert sess in dst_bt
+        assert scan in dst_bt.project('test1').subject(1).session(1)
+        assert scan in dst_bt.project('test1').subject(1)
+        assert scan in dst_bt.project('test1')
+        assert scan in dst_bt
         assert scan.scan_type == 'meg'
         # check some emptyroom values
-        sess2 = src_bf.project('test2').subject('3').session('1')
+        sess2 = src_bt.project('test2').subject('3').session('1')
         assert sess2.scan(task='resting', run='1').emptyroom is not None
 
         # check regex works for scans
@@ -49,15 +49,15 @@ def test_containment():
         # Make sure an error is raised if trying to test for an object that
         # connot possibly be in another.
         with pytest.raises(TypeError):
-            assert 'cats' in src_bf
+            assert 'cats' in src_bt
         with pytest.raises(TypeError):
-            assert dst_bf in src_bf
+            assert dst_bt in src_bt
         with pytest.raises(TypeError):
-            assert dst_bf in proj
+            assert dst_bt in proj
         with pytest.raises(TypeError):
-            assert dst_bf in subj
+            assert dst_bt in subj
         with pytest.raises(TypeError):
-            assert dst_bf in sess
+            assert dst_bt in sess
 
         # Check the paths for the associated `channels`, `events` and
         # `coordsystem` file are correct
@@ -68,7 +68,7 @@ def test_containment():
         # Check that an error is raised when trying to get a specific object
         # that doesn't exist.
         with pytest.raises(NoProjectError):
-            proj = src_bf.project('5')
+            proj = src_bt.project('5')
         with pytest.raises(NoSubjectError):
             sess = proj.subject('5')
         with pytest.raises(NoSessionError):
@@ -76,7 +76,7 @@ def test_containment():
         with pytest.raises(NoScanError):
             scan = sess.scan(task='fake')
 
-        assert len(dst_bf['test1'].contained_files()) == 19
+        assert len(dst_bt['test1'].contained_files()) == 19
 
         # Check that some inherited properties correctly aren't defined for
         # objects they shouldn't be

--- a/bidshandler/tests/test_rename.py
+++ b/bidshandler/tests/test_rename.py
@@ -26,18 +26,18 @@ def test_rename():
         for _, _, files in os.walk(subj.path):
             for fname in files:
                 assert 'sub-2' not in fname
-        sess = subj.session(1)
+        sess = subj.session(2)
         assert 'sub-4' in sess.scans[0].raw_file
 
         # renaming a session
-        sess.rename('2')
-        assert sess.ID == 'ses-2'
+        sess.rename('3')
+        assert sess.ID == 'ses-3'
         for _, _, files in os.walk(subj.path):
             for fname in files:
-                assert 'ses-1' not in fname
+                assert 'ses-2' not in fname
         df = pd.read_csv(sess.scans_tsv, sep='\t')
         for row in df['filename']:
-            assert 'ses-2' in row
+            assert 'ses-3' in row
             assert 'sub-4' in row
 
         # test renaming a folder-less session to have a session label

--- a/bidshandler/tests/test_rename.py
+++ b/bidshandler/tests/test_rename.py
@@ -6,7 +6,7 @@ import shutil
 import os
 import pandas as pd
 
-from bidshandler import BIDSTree, Session
+from bidshandler import BIDSTree
 from bidshandler.constants import test_path
 
 testpath = test_path()

--- a/bidshandler/tests/test_rename.py
+++ b/bidshandler/tests/test_rename.py
@@ -1,0 +1,40 @@
+# test the functionality of renaming folders
+
+import tempfile
+import os.path as op
+import shutil
+import os
+import pandas as pd
+
+from bidshandler import BIDSTree
+from bidshandler.constants import test_path
+
+testpath = test_path()
+TESTPATH1 = op.join(testpath, 'BIDSTEST1')
+
+
+def test_rename():
+    with tempfile.TemporaryDirectory() as tmp:
+        shutil.copytree(TESTPATH1, op.join(tmp, 'BIDSTEST1'))
+        src_bt = BIDSTree(op.join(tmp, 'BIDSTEST1'))
+
+        # renaming a subject
+        subj = src_bt.project('test1').subject(2)
+        subj.rename('4')
+        assert subj.ID == 'sub-4'
+        for _, _, files in os.walk(subj.path):
+            for fname in files:
+                assert 'sub-2' not in fname
+        sess = subj.session(1)
+        assert 'sub-4' in sess.scans[0].raw_file
+
+        # renaming a session
+        sess.rename('2')
+        assert sess.ID == 'ses-2'
+        for _, _, files in os.walk(subj.path):
+            for fname in files:
+                assert 'ses-1' not in fname
+        df = pd.read_csv(sess.scans_tsv, sep='\t')
+        for row in df['filename']:
+            assert 'ses-2' in row
+            assert 'sub-4' in row

--- a/bidshandler/tests/test_rename.py
+++ b/bidshandler/tests/test_rename.py
@@ -6,11 +6,12 @@ import shutil
 import os
 import pandas as pd
 
-from bidshandler import BIDSTree
+from bidshandler import BIDSTree, Session
 from bidshandler.constants import test_path
 
 testpath = test_path()
 TESTPATH1 = op.join(testpath, 'BIDSTEST1')
+TESTPATH2 = op.join(testpath, 'BIDSTEST2')
 
 
 def test_rename():
@@ -38,3 +39,12 @@ def test_rename():
         for row in df['filename']:
             assert 'ses-2' in row
             assert 'sub-4' in row
+
+        # test renaming a folder-less session to have a session label
+        shutil.copytree(TESTPATH2, op.join(tmp, 'BIDSTEST2'))
+        src_bt = BIDSTree(op.join(tmp, 'BIDSTEST2'))
+
+        sess = src_bt.project('test1').subject(2).session('none')
+        orig_path = sess.path
+        sess.rename('1')
+        assert sess.path == op.join(orig_path, 'ses-1')

--- a/bidshandler/tests/test_utils.py
+++ b/bidshandler/tests/test_utils.py
@@ -4,7 +4,8 @@ import tempfile
 import os.path as op
 
 from bidshandler.utils import (_get_bids_params, _bids_params_are_subsets,
-                               _compare, _compare_times, download_test_data)
+                               _compare, _compare_times, download_test_data,
+                               _multi_replace)
 
 
 def test_download_test_data():
@@ -59,3 +60,13 @@ def test__compare():
     assert _compare_times(ref_datetime2, '>', ref_datetime)
     with pytest.raises(TypeError):
         _compare_times(ref_date, '=', str)
+
+
+def test__multi_replace():
+    orig = 'this is a test'
+    new = _multi_replace(orig, [], [])
+    assert new == orig
+    new = _multi_replace(orig, [' '], ['_'])
+    assert new == 'this_is_a_test'
+    new = _multi_replace(orig, [' ', 's', 'tezt'], ['_', 'z', 'thing'])
+    assert new == 'thiz_iz_a_thing'

--- a/bidshandler/utils.py
+++ b/bidshandler/utils.py
@@ -165,6 +165,17 @@ def _copyfiles(src_files, dst_files):
             print('same file!!')
 
 
+def _fix_folderless(session, fname, old_sess_id, old_subj_id):
+    # TODO: join this into _multi_replace?
+    if session.has_no_folder:
+        # replace all the sub-XX with sub-XX_ses-YY
+        fname = fname.replace(old_subj_id, old_subj_id + '_' + old_sess_id)
+        # then replace the sub-XX_ses-YY in the path to sub-XX/ses-YY
+        fname = fname.replace(old_subj_id + '_' + old_sess_id + op.sep,
+                              op.join(old_subj_id, old_sess_id) + op.sep)
+    return fname
+
+
 def _get_bids_params(fname):
     filename, ext = op.splitext(fname)
     f = filename.split('_')

--- a/bidshandler/utils.py
+++ b/bidshandler/utils.py
@@ -66,6 +66,14 @@ def download_test_data(overwrite=True, dst=None):
 
 #region private functions
 
+
+def _file_list(folder):
+    """ List of all the files contained recursively within a directory """
+    for _, _, files in os.walk(folder):
+        for file in files:
+            yield file
+
+
 def _bids_params_are_subsets(params1, params2):
     """
     Equivalent to asking if params1 ⊇ params2.

--- a/bidshandler/utils.py
+++ b/bidshandler/utils.py
@@ -177,6 +177,32 @@ def _get_bids_params(fname):
     return data
 
 
+def _multi_replace(str_in, old, new):
+    """Replace all instances of all strings in `old` with the strings in `new`
+
+    Parameters
+    ----------
+    str_in : str
+        Original string.
+    old : list(str)
+        List of strings to be replaced.
+    new : list(str)
+        List of string to replace with.
+
+    Returns
+    -------
+    str_out : str
+        String with values replaced.
+    """
+    if ((not isinstance(old, list)) or (not isinstance(new, list)) or
+            len(old) != len(new)):
+        raise ValueError
+    str_out = str_in
+    for i in range(len(old)):
+        str_out = str_out.replace(old[i], new[i])
+    return str_out
+
+
 def _prettyprint_xml(xml_str):
     """Take a flat string representation of xml data and pretty print it."""
     curr_indent = 0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,9 +24,9 @@ copyright = '2019, Matt Sanderson'
 author = 'Matt Sanderson'
 
 # The short X.Y version
-version = '0.2.1'
+version = '0.3'
 # The full version, including alpha/beta/rc tags
-release = 'v0.2.1'
+release = 'v0.3dev0'
 
 
 def trim_docstring_with_noqa(app, what, name, obj, options, lines):
@@ -36,10 +36,7 @@ def trim_docstring_with_noqa(app, what, name, obj, options, lines):
 
 
 def setup(app):
-    app.connect(
-        'autodoc-process-docstring',
-        trim_docstring_with_noqa,
-    )
+    app.connect('autodoc-process-docstring', trim_docstring_with_noqa,)
 
 
 # -- General configuration ---------------------------------------------------
@@ -64,9 +61,10 @@ extensions = [
 
 autodoc_default_options = {
     'member-order': 'bysource',
-    'undoc-members': None,
+    'undoc-members': False,
     'show-inheritance': True,
     'inherited-members': True,
+    'special-members': '__contains__,__iter__,__getitem__',
     'exclude-members': '__init__'
 }
 


### PR DESCRIPTION
closes #2  closes #10 

This ended up being a lot more content than I was expecting.
Rename functionality is added to both the `Session` and `Subject` objects.
`Subject`, `Session` and `Scan` have a `delete` method now.
Also updated some of the docstrings and documentation generation code.